### PR TITLE
remove comments in samples list for pt_reweighting

### DIFF
--- a/mutag_calib/configs/pt_reweighting/ptreweighting_run3.py
+++ b/mutag_calib/configs/pt_reweighting/ptreweighting_run3.py
@@ -30,15 +30,12 @@ parameters = defaults.merge_parameters_from_files(default_parameters,
                                                 f"{localdir}/params/plotting_style.yaml",
                                                 update=True)
 
-# samples = [
-#     "QCD_MuEnriched",
-#     "VJets",
-#     "TTto4Q",
-#     "SingleTop",
-#     "DATA_BTagMu"
-# ]
 samples = [
-    "SingleTop"
+    "QCD_MuEnriched",
+    "VJets",
+    "TTto4Q",
+    "SingleTop",
+    "DATA_BTagMu"
 ]
 subsamples = {}
 for s in filter(lambda x: 'DATA_BTagMu' not in x, samples):


### PR DESCRIPTION
Very small fix.
To run the `pt_reweighting`, all files and not only the single top are required. 
From the history I assume, the other samples were commented out for testing and it was forgotten to reset them.